### PR TITLE
Add tsc --noEmit typecheck to build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "tsdown --config ./tsdown.config.ts",
+    "typecheck": "tsc --noEmit",
+    "build": "npm run typecheck && tsdown --config ./tsdown.config.ts",
     "test": "vitest --config vitest.config.unit.ts",
     "test:live": "vitest --config vitest.config.live.ts",
     "lint": "eslint src test test-live ./packages/bicep-deploy-common/src ./packages/bicep-deploy-common/test",

--- a/packages/bicep-deploy-common/package.json
+++ b/packages/bicep-deploy-common/package.json
@@ -32,7 +32,8 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsdown --config ./tsdown.config.mts"
+    "typecheck": "tsc --noEmit",
+    "build": "npm run typecheck && tsdown --config ./tsdown.config.mts"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/bicep-deploy-common/test/handler.test.ts
+++ b/packages/bicep-deploy-common/test/handler.test.ts
@@ -488,7 +488,7 @@ describe("deployment execution", () => {
     const expectedPayload = {
       location: config.location,
       properties: {
-        mode: "Incremental",
+        mode: "Incremental" as const,
         template: files.templateContents,
         parameters: files.parametersContents["parameters"],
         expressionEvaluationOptions: {

--- a/packages/bicep-deploy-common/test/mocks/azureMocks.ts
+++ b/packages/bicep-deploy-common/test/mocks/azureMocks.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 import { Deployments } from "@azure/arm-resources";
 import { DeploymentStacks } from "@azure/arm-resourcesdeploymentstacks";
+import type { MockedObjectDeep } from "@vitest/spy";
 
-export const mockDeploymentsOps: Partial<vi.MockedObjectDeep<Deployments>> = {
+export const mockDeploymentsOps: Partial<MockedObjectDeep<Deployments>> = {
   beginCreateOrUpdateAtSubscriptionScopeAndWait: vi.fn(),
   beginValidateAtSubscriptionScopeAndWait: vi.fn(),
   beginWhatIfAtSubscriptionScopeAndWait: vi.fn(),
@@ -13,7 +14,7 @@ export const mockDeploymentsOps: Partial<vi.MockedObjectDeep<Deployments>> = {
   beginCreateOrUpdateAtTenantScopeAndWait: vi.fn(),
 };
 
-export const mockStacksOps: Partial<vi.MockedObjectDeep<DeploymentStacks>> = {
+export const mockStacksOps: Partial<MockedObjectDeep<DeploymentStacks>> = {
   beginCreateOrUpdateAtSubscriptionAndWait: vi.fn(),
   beginValidateStackAtSubscriptionAndWait: vi.fn(),
   beginDeleteAtSubscriptionAndWait: vi.fn(),

--- a/packages/bicep-deploy-common/test/mocks/bicepNodeMocks.ts
+++ b/packages/bicep-deploy-common/test/mocks/bicepNodeMocks.ts
@@ -7,8 +7,9 @@ import {
   CompileRequest,
   CompileResponse,
 } from "bicep-node";
+import type { MockedObjectDeep } from "@vitest/spy";
 
-const mockBicep: Partial<vi.MockedObjectDeep<Bicep>> = {
+const mockBicep: Partial<MockedObjectDeep<Bicep>> = {
   compile: vi.fn(),
   compileParams: vi.fn(),
   version: vi.fn().mockReturnValue("1.2.3"),
@@ -18,13 +19,15 @@ const mockBicep: Partial<vi.MockedObjectDeep<Bicep>> = {
 export function configureCompileMock(
   mock: (request: CompileRequest) => CompileResponse,
 ) {
-  mockBicep.compile!.mockImplementation(req => Promise.resolve(mock(req)));
+  mockBicep.compile!.mockImplementation((req: CompileRequest) =>
+    Promise.resolve(mock(req)),
+  );
 }
 
 export function configureCompileParamsMock(
   mock: (request: CompileParamsRequest) => CompileParamsResponse,
 ) {
-  mockBicep.compileParams!.mockImplementation(req =>
+  mockBicep.compileParams!.mockImplementation((req: CompileParamsRequest) =>
     Promise.resolve(mock(req)),
   );
 }

--- a/packages/bicep-deploy-common/tsconfig.json
+++ b/packages/bicep-deploy-common/tsconfig.json
@@ -11,6 +11,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
+    "skipLibCheck": true,
     "types": ["vitest/globals"],
   },
   "include": ["src", "test"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "noUnusedLocals": true,
     "allowJs": true,
+    "skipLibCheck": true,
     "types": ["vitest/globals"],
   },
   "include": ["src", "test", "test-live"]


### PR DESCRIPTION
tsdown strips types but does not typecheck, allowing breaking type changes (e.g. from Dependabot bumps) to land silently. Wire 'tsc --noEmit' into the build of both the root action and the bicep-deploy-common package so CI gates every PR on a clean typecheck.

Also fixes latent type errors uncovered by enabling typecheck:

- mocks: vi.MockedObjectDeep used as namespace; switch to type import from @vitest/spy

- bicepNodeMocks: add explicit param types to mockImplementation callbacks

- handler.test: widen 'Incremental' literal with 'as const' for DeploymentMode

- tsconfig: skipLibCheck to ignore upstream node_modules type noise